### PR TITLE
Windows QPA: Don't clip the drawing area

### DIFF
--- a/src/plugins/platforms/windows/qwindowswindow.cpp
+++ b/src/plugins/platforms/windows/qwindowswindow.cpp
@@ -692,15 +692,6 @@ void WindowCreationData::fromWindow(const QWindow *w, const Qt::WindowFlags flag
         style = WS_CHILD;
     }
 
-        // if (!testAttribute(Qt::WA_PaintUnclipped))
-        // ### Commented out for now as it causes some problems, but
-        // this should be correct anyway, so dig some more into this
-#ifdef Q_FLATTEN_EXPOSE
-        if (windowIsOpenGL(w)) // a bit incorrect since the is-opengl status may change from false to true at any time later on
-            style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN; // see SetPixelFormat
-#else
-        style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN ;
-#endif
         if (topLevel) {
             if ((type == Qt::Window || dialog || tool)) {
                 if (!(flags & Qt::FramelessWindowHint)) {
@@ -2317,11 +2308,7 @@ void QWindowsWindow::setWindowState_sys(Qt::WindowStates newState)
 
     if (stateChange & Qt::WindowFullScreen) {
         if (newState & Qt::WindowFullScreen) {
-#ifndef Q_FLATTEN_EXPOSE
-            UINT newStyle = WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_POPUP;
-#else
             UINT newStyle = WS_POPUP;
-#endif
             // Save geometry and style to be restored when fullscreen
             // is turned off again, since on Windows, it is not a real
             // Window state but emulated by changing geometry and style.


### PR DESCRIPTION
It's causing drawing issues in some cases,
and in some rare cases it also increases
the memory consumption, so just remove
the related window styles. It doesn't bring
us much benefit either.

Signed-off-by: Yuhang Zhao <2546789017@qq.com>